### PR TITLE
#162083606 Sign Up controller updated to expect un-enveloped payload

### DIFF
--- a/server/src/v1/controllers/auth.js
+++ b/server/src/v1/controllers/auth.js
@@ -18,10 +18,16 @@ const authController = {
  * @param  {Object} res  Express response object
  */
   signup(req, res) {
-    const { user } = req.body;
-    Validator.check(user, ['email', 'password', 'firstname', 'lastname']);
+    // return res.json([]);
+    let userObject = {};
+    if (req.body.user) {
+      userObject = req.body.user;
+    } else {
+      Object.assign(userObject, req.body);
+    }
+    Validator.check(userObject, ['email', 'password', 'firstname', 'lastname']);
     const errors = Validator.errors();
-    const isEmail = /\S+@\S+\.\S+/.test(user.email);
+    const isEmail = /\S+@\S+\.\S+/.test(userObject.email);
     if (!isEmail) errors.push({ email: 'Email is Invalid' });
     if (errors.length > 0) {
       return res.status(422).send({
@@ -30,14 +36,14 @@ const authController = {
       });
     }
     // if (user.email === 'test@test.com') user.parcels = [4];
-    AuthHelpers.hash(user.password)
+    AuthHelpers.hash(userObject.password)
       .then((hash) => {
         dbHelpers.createUser({
-          email: user.email,
-          firstname: user.firstname,
-          lastname: user.lastname,
-          password: hash, 
-          admin: user.admin,
+          email: userObject.email,
+          firstname: userObject.firstname,
+          lastname: userObject.lastname,
+          password: hash,
+          admin: userObject.admin,
         }).then((newUser) => {
           const uiUser = {};
           Object.assign(uiUser, newUser);


### PR DESCRIPTION
#### What does this PR do?
Updates sign up controller
#### Description of Task to be completed?
* Update sign up controller to expect un-enveloped user credentials payload
#### How should this be manually tested?
* Open up POSTMAN
* Send a request to `POST /auth/signup`
* with user credentials username, password, firstname, lastname
#### Any background context you want to provide?
Before now
* `POST /auth/signup` expected user credentials to be enveloped
* Which is not a usual convention
* Resulting in errors 
Now 
* `POST /auth/signup` expects un-enveloped user credentials
* Natural behavior
#### What are the relevant pivotal tracker stories?
#162083606